### PR TITLE
Add extended option for Hugo

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.123.7'
+          extended: true
       - run: hugo --minify --gc
       - name: Check links
         uses: wjdp/htmltest-action@master


### PR DESCRIPTION
## Summary
- enable Hugo extended version for GH Pages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684298579a508321b8966d3a1c4ca6f3