### PR TITLE
Fix csproj BOM

### DIFF
--- a/tools/PostManager/PostManager.csproj
+++ b/tools/PostManager/PostManager.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- remove BOM from PostManager.csproj so the file starts directly with `<Project>`

## Testing
- `dotnet build tools/PostManager/PostManager.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684299bdbbb0832196fad29c6a661e51