### PR TITLE
Add search, comments and SEO features

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,6 +20,9 @@ jobs:
           hugo-version: '0.123.7'
           extended: true
       - run: hugo --minify --gc
+
+      - name: Build Pagefind Index
+        run: npx -y pagefind --site public
       - name: Check links
         uses: wjdp/htmltest-action@master
         with:

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -2,4 +2,8 @@
 title = '{{ replace .File.ContentBaseName "-" " " | title }}'
 date = {{ .Date }}
 draft = true
+description = ""
+tags = []
+categories = []
+image = ""
 +++

--- a/blog/post.go
+++ b/blog/post.go
@@ -7,58 +7,58 @@ import "fmt"
 // 提供 RenderHTML 方法以取得 HTML 字串
 // <summary>Renderable 介面</summary>
 type Renderable interface {
-    // RenderHTML 產生 HTML 字串
-    RenderHTML() string
+	// RenderHTML 產生 HTML 字串
+	RenderHTML() string
 }
 
 // Post 表示部落格文章
 // <summary>文章物件</summary>
 type Post struct {
-    // Title 文章標題
-    Title string
-    // Type 文章類型
-    Type string
-    // Content 文章內容
-    Content string
+	// Title 文章標題
+	Title string
+	// Type 文章類型
+	Type string
+	// Content 文章內容
+	Content string
 }
 
 // NewPost 建立新的 Post
 func NewPost(title, postType, content string) *Post {
-    return &Post{Title: title, Type: postType, Content: content}
+	return &Post{Title: title, Type: postType, Content: content}
 }
 
 // RenderHTML 將文章渲染為 HTML
 func (p *Post) RenderHTML() string {
-    return fmt.Sprintf("<h1>%s</h1><p>%s</p>", p.Title, p.Content)
+	return fmt.Sprintf("<h1>%s</h1><p>%s</p>", p.Title, p.Content)
 }
 
 // NavItem 導覽列項目
 // <summary>導覽列單一項目</summary>
 type NavItem struct {
-    // Name 名稱
-    Name string
-    // Link 連結
-    Link string
+	// Name 名稱
+	Name string
+	// Link 連結
+	Link string
 }
 
 // HTML 產生 NavItem 的 HTML
 func (n NavItem) HTML() string {
-    return fmt.Sprintf("<li><a href=\"%s\">%s</a></li>", n.Link, n.Name)
+	return fmt.Sprintf("<li><a href=\"%s\">%s</a></li>", n.Link, n.Name)
 }
 
 // NavBar 導覽列
 // <summary>導覽列集合</summary>
 type NavBar struct {
-    // Items 導覽列項目清單
-    Items []NavItem
+	// Items 導覽列項目清單
+	Items []NavItem
 }
 
 // HTML 回傳 NavBar 的 HTML
 func (nb NavBar) HTML() string {
-    result := "<nav><ul>"
-    for _, item := range nb.Items {
-        result += item.HTML()
-    }
-    result += "</ul></nav>"
-    return result
+	result := "<nav><ul>"
+	for _, item := range nb.Items {
+		result += item.HTML()
+	}
+	result += "</ul></nav>"
+	return result
 }

--- a/hugo.toml
+++ b/hugo.toml
@@ -12,6 +12,12 @@ paginate = 5
   description = "歡迎來到 ChiYu 的程式旅程部落格"
   [params.author]
     name = "ChiYu"
+  [params.giscus]
+    enable = true
+    repo = "yourname/yourrepo"
+    repoId = ""
+    category = "Comments"
+    categoryId = ""
   # [params.logo]
   #   logo__png = "images/logo.png"
   #   logo_dark__png = "images/logo-dark.png"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,23 @@
+{{ if .Site.Params.enforceSinglePage -}}
+<meta http-equiv="refresh" content="0; url={{ .Site.BaseURL }}">
+{{- else -}}
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+  {{ partial "head.html" . }}
+  <link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+  <script src="/pagefind/pagefind-ui.js" type="text/javascript"></script>
+  <body>
+    {{ partial "body-top" . }}
+    <main>
+      {{ block "main" . }}{{ end }}
+    </main>
+    {{ partial "footer.html" . }}
+    {{ partial "body-bottom" . }}
+    <script>
+      window.addEventListener('DOMContentLoaded', (event) => {
+          new PagefindUI({ element: "#search", showSubResults: true });
+      });
+    </script>
+  </body>
+</html>
+{{- end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,21 @@
+{{ define "main" }}
+  <section class="blog" id="blog">
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12"><h1>{{ humanize .Type }}</h1></div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12 posts-list">
+          {{ range .Data.Pages }}
+            <article>
+              <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+              <div class=sub-header>
+                {{ .Date.Format (.Site.Params.dateform | default "January 2, 2006") }} · {{ i18n "minuteRead" .ReadingTime }}
+              </div>
+            </article>
+          {{ end }}
+        </div>
+      </div>
+    </div>
+  </section>
+{{ end }}

--- a/layouts/partials/body-top.html
+++ b/layouts/partials/body-top.html
@@ -1,0 +1,60 @@
+{{ if .Site.Params.Feat.googleTagManager }}
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ .Site.Params.Feat.googleTagManager }}"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+{{ end }}
+
+{{ if .IsHome }}
+  <header class="row middle-xs center-xs bg lazyload">
+    <div class="col-xs-12">
+      {{ partial "logo-img.html" . }}
+          {{ with .Site.Params.mdTagline -}}
+              {{ (replace (. | markdownify) "{cursor}" "<span class=\"cursor\">|</span>") | safeHTML }}
+          {{- else -}}
+              <h1>{{ .Site.Params.tagline }}<span class="cursor">|</span></h1>
+          {{- end }}
+          <noscript>
+          <h2>{{ partial "icon" "warning" }}</h2>
+          <h2>{{ i18n "noJsMsg" }}</h2>
+          </noscript>
+        </div>
+  </header>
+{{ end }}
+
+<nav class="row middle-xs center-xs {{ if not .IsHome -}} nav-fixed nav-shadow {{- end }}">
+  <div class="col-xs-6 col-sm-1 logo" style="{{ if not .IsHome }}visibility: visible;{{- end }}">
+    <a href="{{ "#" | relLangURL }}">
+      {{ partial "lazyimg" (dict 
+        "img" (resources.Get .Site.Params.logoSmall)
+        "maxsize" (default "96x" site.Params.Image.NavLogo.resize)
+        "lqipsize" (default "16x" site.Params.Image.NavLogo.resize)
+        "resizeoptions" (default "q92 Gaussian" site.Params.Image.NavLogo.resizeOptions)
+        "alt" "Home"
+        "renderer" "webp"
+        "noscript" false
+      ) }}
+    </a>
+  </div>
+  {{ range .Site.Menus.main }}
+      <div class="col-xs-3 col-sm-2 nav-item">
+        <h3><a href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a></h3>
+      </div>
+  {{ end }}
+  {{ partial "search.html" . }}
+  <div class="col-xs-6 col-sm-1 nav-toggle" style="{{ if not .IsHome -}} visibility: visible; {{- end }}">
+      <a href="" class="nav-icon" onclick="return false">
+        {{ partial "icon" "menu" }}
+      </a>
+  </div>
+</nav>
+
+<section class="nav-full row middle-xs center-xs">
+  <div class="col-xs-12">
+    <div class="row middle-xs center-xs">
+      {{ range .Site.Menus.main }}
+        <div class="col-xs-12"><h1><a href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a></h1></div>
+      {{ end }}
+    </div>
+  </div>
+</section>

--- a/layouts/partials/giscus.html
+++ b/layouts/partials/giscus.html
@@ -1,0 +1,19 @@
+{{ if .Site.Params.giscus.enable }}
+<div class="giscus-comment">
+    <script src="https://giscus.app/client.js"
+            data-repo="{{ .Site.Params.giscus.repo }}"
+            data-repo-id="{{ .Site.Params.giscus.repoId }}"
+            data-category="{{ .Site.Params.giscus.category }}"
+            data-category-id="{{ .Site.Params.giscus.categoryId }}"
+            data-mapping="pathname"
+            data-strict="0"
+            data-reactions-enabled="1"
+            data-emit-metadata="0"
+            data-input-position="bottom"
+            data-theme="preferred_color_scheme"
+            data-lang="zh-TW"
+            crossorigin="anonymous"
+            async>
+    </script>
+</div>
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,71 @@
+{{ if .IsHome -}}
+  {{ .Scratch.Set "title" .Site.Title }}
+{{- else if .Params.heading -}}
+  {{ .Scratch.Set "title" .Params.heading }}
+{{- else -}}
+  {{ .Scratch.Set "title" (printf "%s | %s" .Title .Site.Title) }} 
+{{- end }}
+{{ range .Site.Menus.main -}}
+  {{ $.Page.Scratch.Set .Identifier . }}
+{{- end }}
+<head>
+  {{ partial "seo.html" . }}
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <base href="{{ .Site.BaseURL }}">
+  {{ with .Site.Params.favicon -}}
+    {{ with (resources.Get .) -}}
+        {{ $img := slice (.Fill "192x192 png Lanczos Center") | resources.Concat "favicon.png" }}
+        <link rel="icon" type="image/png" href="{{ $img.Permalink }}">
+    {{- else -}}
+      <link rel="icon" type="image/png" href="{{ . | absURL }}">
+    {{- end }}
+  {{- end }}
+
+  
+
+  {{ with .Site.Params.themeColor }}
+  <meta name="theme-color" content="{{ . }}">
+  {{ end }}
+
+  <link rel="canonical" href="{{ .Permalink }}">
+  
+  {{ with .OutputFormats.Get "RSS" -}}
+    <link href="{{ .Permalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}">
+  {{- end }}
+
+  {{/* resources.ToCSS was deprecated in 0.128.0 */}}
+  {{ if ge .Site.Hugo.Version "0.128.0" -}}
+  <link rel="stylesheet" href="{{ (resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "sass/main.scss" . | css.Sass (dict "targetPath" "style.css" "outputStyle" "compressed") | resources.Fingerprint).Permalink }}">
+  {{- else -}}
+  <link rel="stylesheet" href="{{ (resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "sass/main.scss" . | resources.ToCSS (dict "targetPath" "style.css" "outputStyle" "compressed") | resources.Fingerprint).Permalink }}">
+  {{- end }}
+
+  {{ if .Site.Params.Feat.useStructuredData -}}
+    {{ $s := (resources.Get "person.json" | resources.ExecuteAsTemplate "person.json" .).Content }}
+    <script type="application/ld+json">
+    {{ $s | safeJS }}
+    </script>
+    {{/* Validate what we have rendered so that we don't render something that is not readable by a robot */}}
+    {{ $_ := unmarshal $s }}
+  {{- end }}
+
+  {{ partial "lazyimg-setup" . }}
+
+  {{ if .Site.Params.Feat.googleTagManager }}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ .Site.Params.Feat.googleTagManager }}');</script>
+    <!-- End Google Tag Manager -->
+  {{ end }}
+
+  {{ if .Site.Config.Services.GoogleAnalytics.ID }}
+    {{ template "_internal/google_analytics.html" . }}
+  {{ end }}
+  {{ partial "head-extended.html" . }}
+</head>

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,0 +1,1 @@
+<div id="search" class="search-container"></div>

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -1,0 +1,28 @@
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
+{{- $description := .Description | default (.Summary | plainify | truncate 150) | default .Site.Params.description -}}
+<meta name="description" content="{{ $description }}">
+{{- if .IsPage }}
+<meta property="og:title" content="{{ .Title }}">
+<meta property="og:description" content="{{ $description }}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="{{ .Permalink }}">
+{{- with .Params.image }}
+<meta property="og:image" content="{{ . | absURL }}">
+<meta name="twitter:image" content="{{ . | absURL }}">
+{{- end }}
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ .Title }}">
+<meta name="twitter:description" content="{{ $description }}">
+{{- else }}
+<meta property="og:title" content="{{ .Site.Title }}">
+<meta property="og:description" content="{{ .Site.Params.description }}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ .Permalink }}">
+{{- with .Site.Params.image }}
+<meta property="og:image" content="{{ . | absURL }}">
+<meta name="twitter:image" content="{{ . | absURL }}">
+{{- end }}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="{{ .Site.Title }}">
+<meta name="twitter:description" content="{{ .Site.Params.description }}">
+{{- end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,0 +1,25 @@
+{{ define "main" }}
+  <section class="container">
+    <section class="content">
+      <h1>{{ if .Params.heading }} {{ .Params.heading }} {{ else }} {{ .Title }} {{ end }}</h1>
+      <div class="sub-header">
+        {{ .Date.Format (.Site.Params.dateform | default "January 2, 2006") }} · {{ i18n "minuteRead" .ReadingTime }}
+      </div>
+      <article class="entry-content">
+        {{ .Content }}
+      </article>
+      <div class="pagination">
+        {{ if .PrevInSection }}
+          <a href="{{ .PrevInSection.Permalink }}">&laquo; {{ .PrevInSection.Title }}</a>
+        {{ end }}
+        {{ if .NextInSection }}
+          <a href="{{ .NextInSection.Permalink }}">{{ .NextInSection.Title }} &raquo;</a>
+        {{ end }}
+      </div>
+    </section>
+    <br>
+    {{ if and (eq .Kind "page") (not .Draft) }}
+      {{ partial "giscus.html" . }}
+    {{ end }}
+  </section>
+{{ end }}


### PR DESCRIPTION
## Summary
- integrate Pagefind search and add search box in navigation
- add Giscus comments template and enable settings
- implement SEO meta tag partial
- override theme templates to use new base layout
- update workflow to build Pagefind index
- extend archetypes with SEO fields

## Testing
- `go test ./...`
- `dotnet test ./tools/PostManager.Tests/PostManager.Tests.csproj --nologo` *(fails: command not found)*
- `hugo --minify --gc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ba8981788321935e7ca04b1feb4f