### PR TITLE
Add taxonomy and related posts support

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,6 +15,13 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+      - name: Cache Hugo modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.hugo_cache
+          key: ${{ runner.os }}-hugo-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-hugo-
       - uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.123.7'

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,4 +1,4 @@
-CheckExternal: false
+CheckExternal: true
 IgnoreInternalEmptyHash: true
 IgnoreEmptyHref: true
 IgnoreURLs:

--- a/hugo.toml
+++ b/hugo.toml
@@ -4,6 +4,26 @@ title = 'ChiYu Code Journey'
 theme = 'github.com/kdevo/osprey-delight/v5'
 paginate = 5
 
+[taxonomies]
+  tag = "tags"
+  category = "categories"
+
+[related]
+  threshold = 80
+  includeNewer = true
+  toLower = false
+
+  [[related.indices]]
+    name = "tags"
+    weight = 100
+  [[related.indices]]
+    name = "categories"
+    weight = 80
+  [[related.indices]]
+    name = "date"
+    weight = 10
+    pattern = "2006"
+
 [module]
     [[module.imports]]
         path = 'github.com/kdevo/osprey-delight/v5'

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,21 +1,13 @@
 {{ define "main" }}
-  <section class="blog" id="blog">
-    <div class="container">
-      <div class="row">
-        <div class="col-xs-12"><h1>{{ humanize .Type }}</h1></div>
-      </div>
-      <div class="row">
-        <div class="col-xs-12 posts-list">
-          {{ range .Data.Pages }}
-            <article>
-              <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
-              <div class=sub-header>
-                {{ .Date.Format (.Site.Params.dateform | default "January 2, 2006") }} · {{ i18n "minuteRead" .ReadingTime }}
-              </div>
-            </article>
-          {{ end }}
-        </div>
-      </div>
-    </div>
-  </section>
+<main class="main-content">
+    <h1>{{ .Title }}</h1>
+    <ul class="post-list">
+        {{ range .Pages }}
+        <li>
+            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+            <time>{{ .Date.Format "2006-01-02" }}</time>
+        </li>
+        {{ end }}
+    </ul>
+</main>
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<main class="main-content">
+    <h1>{{ .Title }}</h1>
+    <ul>
+        {{ range .Data.Terms.ByCount }}
+        <li>
+            <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>
+            <span>({{ .Count }})</span>
+        </li>
+        {{ end }}
+    </ul>
+</main>
+{{ end }}

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,0 +1,13 @@
+{{ $related := .Site.RegularPages.Related . | first 5 }}
+{{ with $related }}
+<div class="related-posts">
+    <h3>相關文章</h3>
+    <ul>
+        {{ range . }}
+        <li>
+            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        </li>
+        {{ end }}
+    </ul>
+</div>
+{{ end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -16,6 +16,28 @@
           <a href="{{ .NextInSection.Permalink }}">{{ .NextInSection.Title }} &raquo;</a>
         {{ end }}
       </div>
+
+      <div class="post-taxonomies">
+        {{- with .Params.categories }}
+        <div class="post-categories">
+          <strong>分類:</strong>
+          {{ range . }}
+            <a href="{{ "categories/" | relURL }}{{ . | urlize }}/">{{ . }}</a>
+          {{ end }}
+        </div>
+        {{- end }}
+
+        {{- with .Params.tags }}
+        <div class="post-tags">
+          <strong>標籤:</strong>
+          {{ range . }}
+            <a href="{{ "tags/" | relURL }}{{ . | urlize }}/">#{{ . }}</a>
+          {{ end }}
+        </div>
+        {{- end }}
+      </div>
+
+      {{ partial "related.html" . }}
     </section>
     <br>
     {{ if and (eq .Kind "page") (not .Draft) }}


### PR DESCRIPTION
## Summary
- configure Hugo taxonomies and related content
- display categories and tags on posts
- add related posts partial
- list pages for tags and categories
- enable external link checks and cache Hugo modules in CI

## Testing
- `go test ./...`
- `dotnet test tools/PostManager.Tests/PostManager.Tests.csproj --nologo` *(fails: command not found)*
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842be27dd9c8321bf159709d3bac4a3