### PR TITLE
Add code copy improvements and dark mode toggle

### DIFF
--- a/layouts/partials/body-top.html
+++ b/layouts/partials/body-top.html
@@ -43,7 +43,10 @@
   {{ end }}
   {{ partial "search.html" . }}
   <div class="col-xs-3 col-sm-2 nav-item">
-    <button id="theme-toggle">切換主題</button>
+    <button id="theme-toggle" aria-label="切換主題">
+      <svg class="sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24"><path d="M12 9a3 3 0 100 6 3 3 0 000-6zm0-2a5 5 0 110 10 5 5 0 010-10zM12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32l1.41 1.41M2 12h2m16 0h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"></path></svg>
+      <svg class="moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24"><path d="M11.99 2.007a9.993 9.993 0 018.15 4.312 9.993 9.993 0 01-4.312 8.15 9.993 9.993 0 01-9.936-9.936A9.993 9.993 0 0111.99 2.007z"></path></svg>
+    </button>
   </div>
   <div class="col-xs-6 col-sm-1 nav-toggle" style="{{ if not .IsHome -}} visibility: visible; {{- end }}">
       <a href="" class="nav-icon" onclick="return false">

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -6,9 +6,9 @@
         {{ .Date.Format (.Site.Params.dateform | default "January 2, 2006") }} · {{ i18n "minuteRead" .ReadingTime }}
       </div>
       <article class="entry-content">
-        {{ if .TableOfContents }}
+        {{ if and (gt .WordCount 400) (.TableOfContents) }}
         <aside class="toc">
-          <h2>本文目錄</h2>
+          <h2 class="toc-title">本文目錄</h2>
           {{ .TableOfContents }}
         </aside>
         {{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -18,6 +18,20 @@ div.highlight {
   transition: opacity 0.2s ease-in-out;
 }
 
+/* 程式語言標籤樣式 */
+.code-language-tag {
+  position: absolute;
+  top: 0.5em;
+  left: 0.5em;
+  padding: 0.25em 0.5em;
+  background-color: #333;
+  color: #eee;
+  border: 1px solid #555;
+  border-radius: 3px;
+  font-size: 0.8em;
+  text-transform: uppercase;
+}
+
 /* 滑鼠移入時顯示按鈕 */
 div.highlight:hover .copy-code-button {
   opacity: 1;
@@ -28,6 +42,8 @@ div.highlight:hover .copy-code-button {
   --bg-color: #ffffff;
   --text-color: #333333;
   --link-color: #007bff;
+  --header-bg: #f8f9fa;
+  --border-color: #dee2e6;
 }
 
 /* 深色主題顏色 */
@@ -35,6 +51,8 @@ div.highlight:hover .copy-code-button {
   --bg-color: #1a1a1a;
   --text-color: #e0e0e0;
   --link-color: #64b5f6;
+  --header-bg: #1e1e1e;
+  --border-color: #424242;
 }
 
 /* 套用主題顏色 */
@@ -50,7 +68,49 @@ a {
 
 /* 文章目錄區塊樣式 */
 .toc {
-  border-left: 4px solid #ccc;
-  padding-left: 1em;
-  margin-bottom: 1em;
+  background: #f8f9fa;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  padding: 1em 1.5em;
+  margin-bottom: 2em;
+}
+
+[data-theme='dark'] .toc {
+  background: #2a2a2a;
+}
+
+.toc-title {
+  margin-top: 0;
+  font-size: 1.2em;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.toc ul {
+  padding-left: 1.2em;
+}
+
+.toc li {
+  margin-bottom: 0.5em;
+}
+
+/* 深色模式切換按鈕樣式 */
+#theme-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5em;
+}
+
+[data-theme='light'] .moon {
+  display: none;
+}
+
+[data-theme='dark'] .sun {
+  display: none;
+}
+
+#theme-toggle svg {
+  fill: var(--text-color);
 }

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -1,28 +1,39 @@
 // 頁面載入完成後執行
 document.addEventListener('DOMContentLoaded', () => {
-  // 取得所有程式碼區塊並加入複製按鈕
+  // 取得所有程式碼區塊，加入複製按鈕與語言標籤
   document.querySelectorAll('div.highlight').forEach(block => {
-    // 建立按鈕元素
-    const button = document.createElement('button');
-    button.className = 'copy-code-button';
-    button.type = 'button';
-    button.innerText = 'Copy';
+    // 建立複製按鈕
+    const copyButton = document.createElement('button');
+    copyButton.className = 'copy-code-button';
+    copyButton.type = 'button';
+    copyButton.ariaLabel = 'Copy code to clipboard';
+    copyButton.innerText = 'Copy';
 
     // 點擊按鈕後將程式碼複製到剪貼簿
-    button.addEventListener('click', () => {
+    copyButton.addEventListener('click', () => {
       const code = block.querySelector('code').innerText;
       navigator.clipboard.writeText(code).then(() => {
-        button.innerText = 'Copied!';
+        copyButton.innerText = 'Copied!';
         setTimeout(() => {
-          button.innerText = 'Copy';
+          copyButton.innerText = 'Copy';
         }, 2000);
       }, () => {
-        button.innerText = 'Error';
+        copyButton.innerText = 'Error';
       });
     });
 
-    // 將按鈕放到程式碼區塊最前面
-    block.insertBefore(button, block.firstChild);
+    // 解析程式語言名稱，並建立標籤顯示於程式碼區塊左上角
+    const languageClass = block.classList[1];
+    if (languageClass && languageClass.startsWith('language-')) {
+      const lang = languageClass.replace('language-', '');
+      const langTag = document.createElement('div');
+      langTag.className = 'code-language-tag';
+      langTag.innerText = lang;
+      block.appendChild(langTag);
+    }
+
+    // 將按鈕加入程式碼區塊
+    block.appendChild(copyButton);
   });
 
   // 深色模式切換按鈕


### PR DESCRIPTION
## Summary
- show Table of Contents only when article has more than 400 words
- add sun/moon icons for theme toggle button
- display language tags on highlighted code blocks
- improve code block, TOC and dark mode styles

## Testing
- `hugo --minify --gc`
- `htmltest -c .htmltest.yml ./public`

------
https://chatgpt.com/codex/tasks/task_e_6842fb35b8c4832185c45efeda5385b5