### PR TITLE
Integrate new homepage design

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,29 +1,80 @@
 {{ define "main" }}
-  <section class="container">
-    <!-- 首頁介紹文字 -->
-    <div class="home-intro">
-      {{ .Content }}
-    </div>
+  <!-- 主要容器 -->
+  <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
 
-    <!-- 近期文章列表 -->
-    <h2>近期文章</h2>
-    <ul class="home-post-list">
-      {{ range first 5 (where .Site.RegularPages "Type" "posts") }}
-      <li>
-        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-        <time>{{ .Date.Format "2006-01-02" }}</time>
-      </li>
-      {{ end }}
-    </ul>
+    <!-- 頁首與導覽列 -->
+    <header class="flex justify-between items-center mb-10 sm:mb-16">
+      <a href="{{ "/" | relURL }}" class="text-xl sm:text-2xl font-bold" style="color: var(--text-color);">{{ .Site.Title }}</a>
+      <nav class="flex items-center space-x-4">
+        <a href="{{ "/about/" | relURL }}" class="text-sm sm:text-base hidden sm:block" style="color: var(--text-secondary);">關於我</a>
+        <a href="{{ "/posts/" | relURL }}" class="text-sm sm:text-base hidden sm:block" style="color: var(--text-secondary);">封存</a>
+        <button id="theme-toggle" title="切換深色/淺色主題">
+          <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </nav>
+    </header>
 
-    <!-- 所有標籤 -->
-    <h2>標籤</h2>
-    <ul class="home-tags">
-      {{ range .Site.Taxonomies.tags.ByCount }}
-      <li>
-        <a href="{{ .Page.RelPermalink }}">#{{ .Page.Title }} ({{ .Count }})</a>
-      </li>
-      {{ end }}
-    </ul>
-  </section>
+    <!-- 主要內容 -->
+    <main>
+      <!-- 介紹區塊 -->
+      <section class="text-center mb-12 sm:mb-20">
+        <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mb-4">歡迎來到 ChiYu 的程式旅程</h1>
+        <p class="max-w-2xl mx-auto sm:text-lg" style="color: var(--text-secondary);">
+          {{ .Content }}
+        </p>
+      </section>
+
+      <!-- 最新文章列表 -->
+      <section>
+        <h2 class="text-2xl sm:text-3xl font-bold mb-6 sm:mb-8 border-b pb-3" style="border-color: var(--border-color);">最新文章</h2>
+
+        <div class="space-y-8">
+          {{ range first 3 (where .Site.RegularPages "Type" "posts") }}
+          <article class="p-6 rounded-lg transition-all" style="background-color: var(--card-bg); border: 1px solid var(--border-color);">
+            <a href="{{ .RelPermalink }}" class="block">
+              <header class="mb-2">
+                <h3 class="text-xl sm:text-2xl font-bold leading-tight" style="color: var(--text-color);">{{ .Title }}</h3>
+              </header>
+              {{ with .Params.description }}
+              <p class="mb-3 text-base" style="color: var(--text-secondary);">
+                {{ . }}
+              </p>
+              {{ else }}
+              <p class="mb-3 text-base" style="color: var(--text-secondary);">
+                {{ .Summary }}
+              </p>
+              {{ end }}
+              <footer class="flex items-center justify-between text-sm" style="color: var(--text-secondary);">
+                <span>{{ .Date.Format "2006年1月2日" }}</span>
+                {{ with .Params.tags }}
+                <div class="flex space-x-2">
+                  {{ range . }}
+                  <span class="bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full dark:bg-blue-900 dark:text-blue-200">{{ . }}</span>
+                  {{ end }}
+                </div>
+                {{ end }}
+              </footer>
+            </a>
+          </article>
+          {{ end }}
+        </div>
+
+        <!-- 查看更多 -->
+        <div class="mt-12 text-center">
+          <a href="{{ "/posts/" | relURL }}" class="font-semibold" style="color: var(--link-color);">
+            查看所有文章 &rarr;
+          </a>
+        </div>
+
+      </section>
+    </main>
+
+    <!-- 頁尾 -->
+    <footer class="mt-16 pt-8 border-t text-center text-sm" style="border-color: var(--border-color); color: var(--text-secondary);">
+      <p>&copy; {{ now.Format "2006" }} ChiYu. All Rights Reserved.</p>
+    </footer>
+
+  </div>
 {{ end }}
+

--- a/layouts/partials/head-extended.html
+++ b/layouts/partials/head-extended.html
@@ -1,1 +1,10 @@
+<!-- Google 字體與 Tailwind -->
+{{ if .IsHome }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+{{ end }}
+
+<!-- 自訂樣式 -->
 <link rel="stylesheet" href="/css/custom.css">

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -66,21 +66,25 @@ div.highlight:hover .copy-code-button {
 }
 
 /* 預設（淺色）主題 */
+/* --------- 主題顏色變數 --------- */
 :root {
-  --bg-color: #ffffff;
-  --text-color: #333333;
-  --link-color: #007bff;
-  --header-bg: #f8f9fa;
-  --border-color: #dee2e6;
+  --bg-color: #f8fafc;        /* 背景顏色 */
+  --text-color: #0f172a;      /* 主要文字顏色 */
+  --text-secondary: #64748b;  /* 次要文字顏色 */
+  --border-color: #e2e8f0;    /* 邊框顏色 */
+  --link-color: #2563eb;      /* 連結顏色 */
+  --card-bg: #ffffff;         /* 卡片背景 */
 }
 
 /* 深色主題顏色 */
+/* 深色主題顏色 */
 [data-theme='dark'] {
-  --bg-color: #1a1a1a;
-  --text-color: #e0e0e0;
-  --link-color: #64b5f6;
-  --header-bg: #1e1e1e;
-  --border-color: #424242;
+  --bg-color: #0f172a;
+  --text-color: #f8fafc;
+  --text-secondary: #94a3b8;
+  --border-color: #334155;
+  --link-color: #60a5fa;
+  --card-bg: #1e293b;
 }
 
 /* 套用主題顏色 */
@@ -93,6 +97,41 @@ body {
 a {
   color: var(--link-color);
 }
+
+/* 深淺主題切換按鈕 */
+#theme-toggle {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 9999px; /* 全圓角 */
+  position: relative;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+  transition: background-color 0.2s ease;
+  color: var(--text-secondary);
+}
+
+#theme-toggle:hover {
+  background-color: var(--border-color);
+}
+
+#theme-toggle svg {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+  transition: transform 0.4s ease, opacity 0.4s ease;
+}
+
+html[data-theme='light'] .moon-icon { transform: scale(0); opacity: 0; }
+html[data-theme='light'] .sun-icon { transform: scale(1); opacity: 1; }
+html[data-theme='dark'] .sun-icon { transform: scale(0); opacity: 0; }
+html[data-theme='dark'] .moon-icon { transform: rotate(360deg) scale(1); opacity: 1; }
 
 
 /* ------------------ 文章目錄（側邊欄）樣式 ------------------ */

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -1,7 +1,7 @@
 // 頁面載入完成後執行
 document.addEventListener('DOMContentLoaded', () => {
   // 取得所有程式碼區塊，加入複製按鈕與語言標籤
-  document.querySelectorAll('div.highlight').forEach(block => {
+document.querySelectorAll('div.highlight').forEach(block => {
     // 建立複製按鈕
     const copyButton = document.createElement('button');
     copyButton.className = 'copy-code-button';
@@ -57,5 +57,28 @@ document.addEventListener('DOMContentLoaded', () => {
     }, { rootMargin: '0px 0px -80% 0px' });
 
     headings.forEach(h => observer.observe(h));
+  }
+
+  // -------- 主題切換邏輯 --------
+  const themeToggle = document.getElementById('theme-toggle');
+  if (themeToggle) {
+    const getStoredTheme = () => localStorage.getItem('theme');
+    const getPreferredTheme = () => (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+
+    const setTheme = theme => {
+      document.documentElement.setAttribute('data-theme', theme);
+      localStorage.setItem('theme', theme);
+    };
+
+    // 初始化主題
+    const currentTheme = getStoredTheme() || getPreferredTheme();
+    setTheme(currentTheme);
+
+    // 切換按鈕點擊
+    themeToggle.addEventListener('click', () => {
+      const activeTheme = document.documentElement.getAttribute('data-theme');
+      const newTheme = activeTheme === 'light' ? 'dark' : 'light';
+      setTheme(newTheme);
+    });
   }
 });


### PR DESCRIPTION
## Summary
- update `head-extended` partial to load Tailwind and fonts on home page
- redesign home layout with theme toggle button
- add light/dark theme variables and toggle styles
- implement theme switching logic in custom JS

## Testing
- `hugo --minify --gc`
- `htmltest -c .htmltest.yml ./public`


------
https://chatgpt.com/codex/tasks/task_e_68430a49e2188321a4b3d76834e20568