### PR TITLE
Fix trailing slash for about link

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -63,7 +63,8 @@ paginate = 5
     weight = 20
   [[menu.main]]
     name = '關於'
-    pageRef = '/about'
+    # 導向關於頁面，路徑需以斜線結尾避免 htmltest 連結錯誤
+    pageRef = '/about/'
     weight = 30
 
 [markup]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -55,7 +55,8 @@
         <header class="flex justify-between items-center py-6 border-b" style="border-color: var(--border-color);">
             <a href="/" class="text-xl sm:text-2xl font-bold" style="color: var(--text-color);">{{ .Site.Title }}</a>
             <nav class="flex items-center space-x-4">
-                <a href="/about" class="text-sm sm:text-base hidden sm:block" style="color: var(--text-secondary);">關於我</a>
+                <!-- 導向關於頁面的連結，需以斜線結尾避免 htmltest 錯誤 -->
+                <a href="/about/" class="text-sm sm:text-base hidden sm:block" style="color: var(--text-secondary);">關於我</a>
                 <button id="theme-toggle" title="切換深色/淺色主題">
                     <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
                     <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>


### PR DESCRIPTION
## Summary
- avoid htmltest errors by adding trailing slash to the About page link
- update navigation menu config

## Testing
- `hugo --minify --gc`
- `htmltest ./public -c .htmltest.yml`

------
https://chatgpt.com/codex/tasks/task_e_68431639ab4883218145810e76c5f9e0