### PR TITLE
Add tag system

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -46,6 +46,23 @@
         .post-toc-sidebar nav#TableOfContents a.active { color: var(--link-color); border-left-color: var(--link-color); transform: translateX(5px); font-weight: 600; }
         @media (max-width: 1024px) { .post-toc-sidebar { display: none; } }
         .prose .not-prose { all: revert; }
+
+        /* 標籤藥丸樣式 */
+        .tag-pill {
+            display: inline-block;
+            font-size: 0.75rem;
+            font-weight: 600;
+            background-color: var(--border-color);
+            color: var(--text-secondary);
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            text-decoration: none;
+            transition: all 0.2s ease;
+        }
+
+        a.tag-pill:hover {
+            opacity: 0.8;
+        }
     </style>
 </head>
 <body class="antialiased">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,25 @@
+{{ define "main" }}
+<main>
+    <section class="mb-12 sm:mb-16">
+        <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mb-4">
+            {{ if eq .Kind "section" }}
+                {{ .Title }}
+            {{ else if eq .Kind "taxonomy" }}
+                {{ .Data.Singular }}: {{ .Title }}
+            {{ else }}
+                {{ .Title }}
+            {{ end }}
+        </h1>
+    </section>
+
+    <section>
+        <div class="space-y-8">
+            {{ range .Paginator.Pages }}
+                {{ .Render "card" }}
+            {{ end }}
+        </div>
+    </section>
+    
+    {{ partial "pagination.html" . }}
+</main>
+{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,39 +1,23 @@
 {{ define "main" }}
-<div class="flex justify-center gap-8 lg:gap-12 py-8 sm:py-12">
-
-    <main class="w-full max-w-4xl min-w-0">
-        <article class="prose">
-            <header class="mb-8">
-                <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mb-4 !mt-0">{{ .Title }}</h1>
-                <p class="text-base" style="color: var(--text-secondary);">
-                    發布於 {{ .Date.Format "2006年1月2日" }}
-                    {{ with .Params.tags }}
-                    &middot; 
-                    <span class="inline-flex space-x-2">
-                        {{ range . }}
-                        <span class="text-xs font-semibold bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full dark:bg-blue-900 dark:text-blue-200">{{ . }}</span>
-                        {{ end }}
-                    </span>
-                    {{ end }}
-                </p>
-            </header>
-            
-            {{ .Content }}
-
-        </article>
-
-        <div id="giscus-container" class="mt-16 pt-8 border-t not-prose" style="border-color: var(--border-color);">
-            </div>
-    </main>
-    
+<div class="py-8 sm:py-12">
     {{ if and (gt .WordCount 400) .TableOfContents }}
-    <aside class="post-toc-sidebar">
-        <div class="toc-sticky-container">
-            <h3 class="toc-title">本文目錄</h3>
-            {{ .TableOfContents }}
-        </div>
-    </aside>
+    <div class="flex justify-center gap-8 lg:gap-12">
+        <main class="w-full max-w-4xl min-w-0">
+            {{ partial "content-body.html" . }}
+        </main>
+        <aside class="post-toc-sidebar">
+            <div class="toc-sticky-container">
+                <h3 class="toc-title">本文目錄</h3>
+                {{ .TableOfContents }}
+            </div>
+        </aside>
+    </div>
+    {{ else }}
+    <div class="flex justify-center">
+        <main class="w-full max-w-4xl min-w-0">
+             {{ partial "content-body.html" . }}
+        </main>
+    </div>
     {{ end }}
-    
 </div>
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,14 @@
+{{ define "main" }}
+<main>
+    <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mb-8">{{ .Title }}</h1>
+    
+    <div class="flex flex-wrap gap-4 items-center">
+        {{ range .Data.Terms.ByCount }}
+        <a href="{{ .Page.RelPermalink }}" class="block px-4 py-2 rounded-lg text-base transition-all" style="background-color: var(--card-bg); border: 1px solid var(--border-color); color: var(--text-secondary);">
+            {{ .Page.Title }}
+            <span class="ml-2 text-sm px-2 py-0.5 rounded-full" style="background-color: var(--bg-color);">{{ .Count }}</span>
+        </a>
+        {{ end }}
+    </div>
+</main>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
 <main>
     <section class="text-center mb-12 sm:mb-20">
         <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mb-4">{{ .Site.Params.description | default "歡迎來到我的部落格" }}</h1>
-         <div class="max-w-2xl mx-auto sm:text-lg" style="color: var(--text-secondary);">
+        <div class="max-w-2xl mx-auto sm:text-lg" style="color: var(--text-secondary);">
             {{ .Content }}
         </div>
     </section>
@@ -11,7 +11,7 @@
         <h2 class="text-2xl sm:text-3xl font-bold mb-6 sm:mb-8 border-b pb-3" style="border-color: var(--border-color);">最新文章</h2>
         
         <div class="space-y-8">
-            {{ range first 5 .Site.RegularPages }}
+            {{ range first 5 .Site.RegularPages.ByDate.Reverse }}
             <article class="p-6 rounded-lg transition-all" style="background-color: var(--card-bg); border: 1px solid var(--border-color);">
                 <a href="{{ .Permalink }}" class="block">
                     <header class="mb-2">
@@ -20,9 +20,16 @@
                     <p class="mb-3 text-base" style="color: var(--text-secondary);">
                         {{ .Summary | truncate 120 }}
                     </p>
-                    <footer class="text-sm" style="color: var(--text-secondary);">
+                    <footer class="flex items-center justify-between text-sm flex-wrap gap-2" style="color: var(--text-secondary);">
                         <span>{{ .Date.Format "2006年1月2日" }}</span>
-                    </footer>
+                        {{ with .Params.tags }}
+                        <div class="flex flex-wrap gap-2">
+                            {{ range . }}
+                            <span class="tag-pill">{{ . }}</span>
+                            {{ end }}
+                        </div>
+                        {{ end }}
+                        </footer>
                 </a>
             </article>
             {{ end }}

--- a/layouts/partials/content-body.html
+++ b/layouts/partials/content-body.html
@@ -1,0 +1,24 @@
+<article class="prose max-w-none">
+    <header class="mb-8">
+        <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mb-4 !mt-0">{{ .Title }}</h1>
+        {{ if eq .Type "posts" }}
+        <p class="text-base" style="color: var(--text-secondary);">
+            發布於 {{ .Date.Format "2006年1月2日" }}
+            {{ with .Params.tags }}
+            &middot; 
+            <span class="inline-flex flex-wrap gap-2 items-center">
+                {{ range . }}
+                <a href="{{ "/tags/" | relURL }}{{ . | urlize }}/" class="tag-pill">{{ . }}</a>
+                {{ end }}
+            </span>
+            {{ end }}
+            </p>
+        {{ end }}
+    </header>
+    
+    {{ .Content }}
+</article>
+
+{{ if eq .Type "posts" }}
+<div id="giscus-container" class="mt-16 pt-8 border-t not-prose" style="border-color: var(--border-color);"></div>
+{{ end }}

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,0 +1,15 @@
+{{ if gt .Paginator.TotalPages 1 }}
+<nav class="mt-8 flex justify-center" aria-label="Pagination">
+    <ul class="inline-flex items-center space-x-2">
+        {{ with .Paginator.Prev }}
+        <li><a href="{{ .URL }}" class="px-3 py-1 border rounded" style="border-color: var(--border-color);">上一頁</a></li>
+        {{ end }}
+        {{ range .Paginator.Pagers }}
+        <li><a href="{{ .URL }}" class="px-3 py-1 border rounded {{ if eq . .Paginator }}font-bold{{ end }}" style="border-color: var(--border-color);">{{ .PageNumber }}</a></li>
+        {{ end }}
+        {{ with .Paginator.Next }}
+        <li><a href="{{ .URL }}" class="px-3 py-1 border rounded" style="border-color: var(--border-color);">下一頁</a></li>
+        {{ end }}
+    </ul>
+</nav>
+{{ end }}

--- a/layouts/posts/card.html
+++ b/layouts/posts/card.html
@@ -1,0 +1,20 @@
+<article class="p-6 rounded-lg transition-all" style="background-color: var(--card-bg); border: 1px solid var(--border-color);">
+    <a href="{{ .Permalink }}" class="block">
+        <header class="mb-2">
+            <h3 class="text-xl sm:text-2xl font-bold leading-tight" style="color: var(--text-color);">{{ .Title }}</h3>
+        </header>
+        <p class="mb-3 text-base" style="color: var(--text-secondary);">
+            {{ .Summary | truncate 120 }}
+        </p>
+        <footer class="flex items-center justify-between text-sm flex-wrap gap-2" style="color: var(--text-secondary);">
+            <span>{{ .Date.Format "2006年1月2日" }}</span>
+            {{ with .Params.tags }}
+            <div class="flex flex-wrap gap-2">
+                {{ range . }}
+                <span class="tag-pill">{{ . }}</span>
+                {{ end }}
+            </div>
+            {{ end }}
+        </footer>
+    </a>
+</article>


### PR DESCRIPTION
## Summary
- create `content-body.html` partial to render article header with tags
- display tags on posts and index page
- add tag style and markup renderer
- add taxonomy templates for terms and lists
- add pagination and card partials

## Testing
- `hugo --gc --minify`

------
https://chatgpt.com/codex/tasks/task_e_68431f7f11c083218edbed6e5fc88ec4