### PR TITLE
Fix list and term templates

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,18 +1,24 @@
-<!-- 文章列表頁範本 -->
+<!-- 文章列表頁範本，用於呈現文章、標籤或分類列表 -->
 {{ define "main" }}
 <main>
+    <!-- 置頂區塊：頁面標題與標籤、分類資訊 -->
     <section class="mb-12 sm:mb-16">
-        <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mb-4">
+        <header class="border-b pb-6 mb-6" style="border-color: var(--border-color);">
             {{ if .IsSection }}
-                {{ .Title }}
+                <!-- 一般文章列表 -->
+                <h1 class="text-3xl sm:text-5xl font-bold tracking-tight">{{ .Title }}</h1>
             {{ else if .IsTaxonomyType }}
-                {{ .Data.Singular | i18n }}: {{ .Title }}
+                <!-- 標籤或分類列表頁 -->
+                <p class="text-lg" style="color: var(--text-secondary);">{{ .Data.Singular | i18n | title }}</p>
+                <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mt-1">{{ .Title }}</h1>
             {{ else }}
-                {{ .Title }}
+                <!-- 其他情況，如搜尋結果等 -->
+                <h1 class="text-3xl sm:text-5xl font-bold tracking-tight">{{ .Title }}</h1>
             {{ end }}
-        </h1>
+        </header>
     </section>
 
+    <!-- 文章卡片清單 -->
     <section>
         <div class="space-y-8">
             {{ range .Paginator.Pages }}
@@ -21,6 +27,7 @@
         </div>
     </section>
     
+    <!-- 分頁導覽 -->
     {{ partial "pagination.html" . }}
 </main>
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,11 +1,15 @@
-<!-- 所有標籤列表頁 -->
+<!-- 標籤或分類彙總頁範本 -->
 {{ define "main" }}
 <main>
-    <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mb-8">{{ .Title }}</h1>
+    <!-- 頁面標題 -->
+    <header class="border-b pb-6 mb-8" style="border-color: var(--border-color);">
+        <h1 class="text-3xl sm:text-5xl font-bold tracking-tight">{{ .Title }}</h1>
+    </header>
     
+    <!-- 依照計數列出所有詞彙 -->
     <div class="flex flex-wrap gap-4 items-center">
         {{ range .Data.Terms.ByCount }}
-        <a href="{{ .Page.RelPermalink }}" class="block px-4 py-2 rounded-lg text-base transition-all" style="background-color: var(--card-bg); border: 1px solid var(--border-color); color: var(--text-secondary);">
+        <a href="{{ .Page.RelPermalink }}" class="block px-4 py-2 rounded-lg text-lg transition-all" style="background-color: var(--card-bg); border: 1px solid var(--border-color); color: var(--text-secondary);">
             {{ .Page.Title }}
             <span class="ml-2 text-sm px-2 py-0.5 rounded-full" style="background-color: var(--bg-color);">{{ .Count }}</span>
         </a>


### PR DESCRIPTION
## Summary
- improve list page rendering for sections, tags and categories
- add term summary page template

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432b8c056483219918398caf7fd5c3