### PR TITLE
Fix list and terms templates

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
                 <h1 class="text-3xl sm:text-5xl font-bold tracking-tight">{{ .Title }}</h1>
             {{ else if .IsTaxonomyType }}
                 <!-- 標籤或分類列表頁 -->
-                <p class="text-lg" style="color: var(--text-secondary);">{{ .Data.Singular | i18n | title }}</p>
+                <p class="text-lg" style="color: var(--text-secondary);">{{ .Data.Singular | title }}</p>
                 <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mt-1">{{ .Title }}</h1>
             {{ else }}
                 <!-- 其他情況，如搜尋結果等 -->

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -9,7 +9,7 @@
     <!-- 依照計數列出所有詞彙 -->
     <div class="flex flex-wrap gap-4 items-center">
         {{ range .Data.Terms.ByCount }}
-        <a href="{{ .Page.RelPermalink }}" class="block px-4 py-2 rounded-lg text-lg transition-all" style="background-color: var(--card-bg); border: 1px solid var(--border-color); color: var(--text-secondary);">
+        <a href="{{ .Page.RelPermalink }}" class="block px-4 py-2 rounded-lg text-base transition-all" style="background-color: var(--card-bg); border: 1px solid var(--border-color); color: var(--text-secondary);">
             {{ .Page.Title }}
             <span class="ml-2 text-sm px-2 py-0.5 rounded-full" style="background-color: var(--bg-color);">{{ .Count }}</span>
         </a>


### PR DESCRIPTION
## Summary
- adjust list template taxonomy header
- correct terms list anchor style

## Testing
- `hugo --gc --minify`
- `htmltest -c .htmltest.yml ./public` *(fails: missing doctype)*

------
https://chatgpt.com/codex/tasks/task_e_68432d8ab3d08321b14b2cab3e1f9abc