### PR TITLE
Add calendar sidebar component

### DIFF
--- a/layouts/partials/calendar.html
+++ b/layouts/partials/calendar.html
@@ -1,0 +1,58 @@
+{{/* 抓取網站建置時的當下時間 */}}
+{{ $now := now }}
+{{ $current_year := $now.Year }}
+{{ $current_month := $now.Month }}
+{{ $current_month_str := printf "%d" $current_month }}
+
+{{/* 找出這個月的第一天和最後一天 */}}
+{{ $first_of_month := time (printf "%d-%02d-01" $current_year $current_month) }}
+{{ $last_of_month := $first_of_month.AddDate 0 1 -1 }}
+
+{{/* 建立一個字典(map)，用來存放這個月內有發表文章的日期 */}}
+{{ $posted_days := dict }}
+{{ $pages_in_month := where .Site.RegularPages "Date" "le" $last_of_month }}
+{{ $pages_in_month = where $pages_in_month "Date" "ge" $first_of_month }}
+{{ range $pages_in_month }}
+    {{ $day_key := string .Date.Day }}
+    {{ $posted_days = merge $posted_days (dict $day_key true) }}
+{{ end }}
+
+<div class="mt-8">
+    <h3 class="text-xl font-bold mb-4 pb-2 border-b" style="border-color: var(--border-color);">文章月曆</h3>
+    <div class="calendar-widget">
+        {{/* 月曆標頭，顯示 年/月 */}}
+        <div class="flex justify-between items-center mb-2 font-semibold">
+            <span>{{ $current_year }} 年 {{ $current_month_str }} 月</span>
+        </div>
+
+        {{/* 星期標頭 */}}
+        <div class="grid grid-cols-7 text-center text-xs gap-y-2" style="color: var(--text-secondary);">
+            <span>日</span><span>一</span><span>二</span><span>三</span><span>四</span><span>五</span><span>六</span>
+        </div>
+
+        {{/* 日期格子 */}}
+        <div class="grid grid-cols-7 text-center text-sm mt-2 gap-y-2">
+            {{/* 在第一天開始前，填上空白的格子 */}}
+            {{ range seq $first_of_month.Weekday }}
+                <div></div>
+            {{ end }}
+
+            {{/* 產生當月的所有日期 (1號到最後一天) */}}
+            {{ range seq $last_of_month.Day }}
+                {{ $day := . }}
+                {{/* 檢查今天是否有文章 */}}
+                {{ $day_key := string $day }}
+                {{ if isset $posted_days $day_key }}
+                    {{/* 如果有文章，就建立一個指向該日期的連結 */}}
+                    {{ $day_link := printf "/%d/%02d/%02d/" $current_year $current_month $day | relURL }}
+                    <a href="{{ $day_link }}" class="block p-1 rounded-full transition-colors font-bold" style="color: var(--link-color); text-decoration: underline; text-decoration-thickness: 2px;">
+                        {{ $day }}
+                    </a>
+                {{ else }}
+                    {{/* 如果沒文章，就只顯示日期數字 */}}
+                    <span class="block p-1">{{ $day }}</span>
+                {{ end }}
+            {{ end }}
+        </div>
+    </div>
+</div>

--- a/layouts/partials/tag_sidebar.html
+++ b/layouts/partials/tag_sidebar.html
@@ -25,5 +25,7 @@
             </div>
         </div>
         {{ end }}
+
+        {{ partial "calendar.html" . }}
     </div>
 </aside>


### PR DESCRIPTION
## Summary
- add a sidebar calendar widget in `calendar.html`
- render the new component from `tag_sidebar.html`

## Testing
- `hugo --minify --gc`
- `htmltest -c .htmltest.yml ./public` *(fails: target does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68450442ed288321be8a09a49613b948